### PR TITLE
Fix paths filtering in the case of empty filter

### DIFF
--- a/common/src/common-utils.ts
+++ b/common/src/common-utils.ts
@@ -13,9 +13,6 @@ export async function execCommand(command: string): Promise<string> {
 }
 
 export function setOutputs(values: Record<string, unknown>): void {
-
-  setOutput('json', JSON.stringify(values));
-
   for (const [key, value] of Object.entries(values)) {
     setOutput(key, stringifyForShell(value));
   }

--- a/common/src/common-utils.ts
+++ b/common/src/common-utils.ts
@@ -1,4 +1,6 @@
+import { setOutput } from '@actions/core';
 import { getExecOutput } from '@actions/exec'
+import { stringifyForShell } from './serialization-utils';
 
 export async function execCommand(command: string): Promise<string> {
   const { stdout, stderr, exitCode } = await getExecOutput(command)
@@ -8,4 +10,13 @@ export async function execCommand(command: string): Promise<string> {
   }
 
   return stdout.trim()
+}
+
+export function setOutputs(values: Record<string, unknown>): void {
+
+  setOutput('json', JSON.stringify(values));
+
+  for (const [key, value] of Object.entries(values)) {
+    setOutput(key, stringifyForShell(value));
+  }
 }

--- a/common/src/constants.ts
+++ b/common/src/constants.ts
@@ -1,7 +1,6 @@
 
 export const inputs = {
     GH_TOKEN: 'gh-token',
-    OUTPUT: 'output',
     PATHS: 'paths',
 } as const;
 

--- a/common/src/path-utils.test.ts
+++ b/common/src/path-utils.test.ts
@@ -11,6 +11,11 @@ describe('path utils', () => {
             },
             {
                 paths: ['a.ts', 'a.js', 'b.md'],
+                patterns: [],
+                expected: ['a.ts', 'a.js', 'b.md']
+            },
+            {
+                paths: ['a.ts', 'a.js', 'b.md'],
                 patterns: ['b*.*'],
                 expected: ['b.md']
             },

--- a/common/src/path-utils.ts
+++ b/common/src/path-utils.ts
@@ -26,11 +26,13 @@ function filterPathsImpl(
 ): string[] {
     return patterns?.length === 0
         ? paths
-        : paths.filter(path => {
-            return patterns.reduce((prevResult, pattern) => {
-                return pattern.startsWith(NEGATION)
-                    ? prevResult && !match(path, pattern.substring(1))
-                    : prevResult || match(path, pattern);
-            }, false);
-        });
+        : paths.filter(path => testPath(path, patterns));
+}
+
+export function testPath(path: string, patterns: string[]): boolean {
+    return patterns.reduce((prevResult, pattern) => {
+        return pattern.startsWith(NEGATION)
+            ? prevResult && !match(path, pattern.substring(1))
+            : prevResult || match(path, pattern);
+    }, false);
 }

--- a/common/src/path-utils.ts
+++ b/common/src/path-utils.ts
@@ -24,11 +24,13 @@ function filterPathsImpl(
     paths: string[],
     patterns: string[],
 ): string[] {
-    return paths.filter(path => {
-        return patterns.reduce((prevResult, pattern) => {
-            return pattern.startsWith(NEGATION)
-                ? prevResult && !match(path, pattern.substring(1))
-                : prevResult || match(path, pattern);
-        }, false);
-    });
+    return patterns?.length === 0
+        ? paths
+        : paths.filter(path => {
+            return patterns.reduce((prevResult, pattern) => {
+                return pattern.startsWith(NEGATION)
+                    ? prevResult && !match(path, pattern.substring(1))
+                    : prevResult || match(path, pattern);
+            }, false);
+        });
 }

--- a/common/src/pr-utils.ts
+++ b/common/src/pr-utils.ts
@@ -1,6 +1,7 @@
 
-import * as core from '@actions/core'
-import { context, getOctokit } from '@actions/github'
+import * as core from '@actions/core';
+import { context, getOctokit } from '@actions/github';
+import { components } from '@octokit/openapi-types';
 import { execCommand } from './common-utils';
 
 export async function getPrRevisionRange(): Promise<{
@@ -42,14 +43,19 @@ function normalizeCommit(commit: string) {
     return commit === '0000000000000000000000000000000000000000' ? 'HEAD^' : commit;
 }
 
-export async function getChangedFiles(token: string): Promise<string[]> {
+interface ChangedFile {
+    filename: string;
+    status: components['schemas']['diff-entry']['status'];
+}
+
+export async function getChangedFiles(token: string): Promise<ChangedFile[]> {
     return getChangedFilesImpl(token).then((files) => {
         core.info(`${files.length} changed files: ${JSON.stringify(files, undefined, 2)}`)
         return files;
     });
 }
 
-async function getChangedFilesImpl(token: string): Promise<string[]> {
+async function getChangedFilesImpl(token: string): Promise<ChangedFile[]> {
     try {
         const octokit = getOctokit(token);
 
@@ -58,13 +64,13 @@ async function getChangedFilesImpl(token: string): Promise<string[]> {
             return [];
         }
 
-        const files = await octokit.paginate(octokit.rest.pulls.listFiles, {
+        const entries = await octokit.paginate(octokit.rest.pulls.listFiles, {
             owner: context.repo.owner,
             repo: context.repo.repo,
             pull_number: context.payload.pull_request.number,
         });
 
-        return files.map(file => file.filename);
+        return entries.map(({ filename, status }) => ({ filename, status }));
     } catch (error) {
         core.setFailed(`Getting changed files failed with error: ${error}`);
         return [];

--- a/common/src/pr-utils.ts
+++ b/common/src/pr-utils.ts
@@ -44,7 +44,7 @@ function normalizeCommit(commit: string) {
 }
 
 interface ChangedFile {
-    filename: string;
+    path: string;
     status: components['schemas']['diff-entry']['status'];
 }
 
@@ -70,7 +70,7 @@ async function getChangedFilesImpl(token: string): Promise<ChangedFile[]> {
             pull_number: context.payload.pull_request.number,
         });
 
-        return entries.map(({ filename, status }) => ({ filename, status }));
+        return entries.map(({ filename, status }) => ({ path: filename, status }));
     } catch (error) {
         core.setFailed(`Getting changed files failed with error: ${error}`);
         return [];

--- a/common/src/serialization-utils.test.ts
+++ b/common/src/serialization-utils.test.ts
@@ -1,0 +1,23 @@
+import { stringifyForShell } from "./serialization-utils";
+
+describe('action utils', () => {
+
+  describe(stringifyForShell.name, () => {
+    test.each([
+      { value: 123, expected: '123' },
+      { value: 'abc', expected: 'abc' },
+    ])('scalar cases [%#]', ({ value, expected }) => {
+      expect(stringifyForShell(value)).toEqual(expected);
+    });
+  });
+
+  describe(stringifyForShell.name, () => {
+    test.each([
+      { value: [123, 456], expected: '123 456' },
+      { value: ['abc', 'def'], expected: '\'abc\' \'def\'' },
+    ])('array values [%#]', ({ value, expected }) => {
+      expect(stringifyForShell(value)).toEqual(expected);
+    });
+  });
+
+});

--- a/common/src/serialization-utils.ts
+++ b/common/src/serialization-utils.ts
@@ -18,7 +18,6 @@ export function stringifyForShell(value: unknown): string {
     case 'string':
       return value;
 
-
     case 'object':
       if (Array.isArray(value)) {
         return value.map(stringifyArrayItem).join(' ');

--- a/common/src/serialization-utils.ts
+++ b/common/src/serialization-utils.ts
@@ -1,0 +1,36 @@
+function stringifyArrayItem(item: unknown): string {
+  switch (typeof item) {
+    case 'number':
+      return item.toString();
+
+    case 'string':
+      return `'${item}'`;
+
+    default:
+      return JSON.stringify(item);
+  }
+}
+
+export function stringifyForShell(value: unknown): string {
+
+  switch (typeof value) {
+
+    case 'string':
+      return value;
+
+
+    case 'object':
+      if (Array.isArray(value)) {
+        return value.map(stringifyArrayItem).join(' ');
+      }
+
+      if (value === null) {
+        return '';
+      }
+
+      return value.toString();
+
+    default:
+      return JSON.stringify(value);
+  }
+}

--- a/get-changed-files/action.yml
+++ b/get-changed-files/action.yml
@@ -11,11 +11,6 @@ inputs:
     description: Semicolon separated globs
     required: false
 
-  output:
-    description: Output file path
-    required: true
-
-
 runs:
   using: node16
   main: dist/index.js

--- a/get-changed-files/dist/index.js
+++ b/get-changed-files/dist/index.js
@@ -266,7 +266,7 @@ function getChangedFilesImpl(token) {
                 repo: github_1.context.repo.repo,
                 pull_number: github_1.context.payload.pull_request.number,
             });
-            return entries.map(({ filename, status }) => ({ filename, status }));
+            return entries.map(({ filename, status }) => ({ path: filename, status }));
         }
         catch (error) {
             core.setFailed(`Getting changed files failed with error: ${error}`);
@@ -576,13 +576,16 @@ function run() {
             console.log('patterns: ' + JSON.stringify(pathPatterns, undefined, 2));
             const changedFiles = yield (0, common_1.getChangedFiles)(token);
             const filteredFiles = pathPatterns.length > 0
-                ? changedFiles.filter(({ filename }) => (0, common_1.testPath)(filename, pathPatterns))
+                ? changedFiles.filter(({ path }) => (0, common_1.testPath)(path, pathPatterns))
                 : changedFiles;
             (0, common_1.ensureDir)(output);
-            fs.writeFileSync(output, JSON.stringify(filteredFiles.map(({ filename }) => ({ filename })), undefined, 2));
+            fs.writeFileSync(output, JSON.stringify(filteredFiles.map(({ path }) => ({ filename: path })), undefined, 2));
             (0, common_1.setOutputs)({
-                json: JSON.stringify(filteredFiles, undefined, 2),
-                files: filteredFiles.map(e => e.filename),
+                json: {
+                    files: JSON.stringify(filteredFiles, undefined, 2),
+                    count: filteredFiles.length,
+                },
+                files: filteredFiles.map(e => e.path),
                 count: filteredFiles.length,
             });
         }

--- a/get-changed-files/dist/index.js
+++ b/get-changed-files/dist/index.js
@@ -144,13 +144,15 @@ function filterPaths(paths, patterns) {
 }
 exports.filterPaths = filterPaths;
 function filterPathsImpl(paths, patterns) {
-    return paths.filter(path => {
-        return patterns.reduce((prevResult, pattern) => {
-            return pattern.startsWith(NEGATION)
-                ? prevResult && !match(path, pattern.substring(1))
-                : prevResult || match(path, pattern);
-        }, false);
-    });
+    return (patterns === null || patterns === void 0 ? void 0 : patterns.length) === 0
+        ? paths
+        : paths.filter(path => {
+            return patterns.reduce((prevResult, pattern) => {
+                return pattern.startsWith(NEGATION)
+                    ? prevResult && !match(path, pattern.substring(1))
+                    : prevResult || match(path, pattern);
+            }, false);
+        });
 }
 
 

--- a/get-changed-files/dist/index.js
+++ b/get-changed-files/dist/index.js
@@ -31,7 +31,6 @@ function execCommand(command) {
 }
 exports.execCommand = execCommand;
 function setOutputs(values) {
-    (0, core_1.setOutput)('json', JSON.stringify(values));
     for (const [key, value] of Object.entries(values)) {
         (0, core_1.setOutput)(key, (0, serialization_utils_1.stringifyForShell)(value));
     }
@@ -135,7 +134,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.filterPaths = void 0;
+exports.testPath = exports.filterPaths = void 0;
 const core = __importStar(__nccwpck_require__(5316));
 const minimatch_1 = __nccwpck_require__(148);
 const NEGATION = '!';
@@ -155,14 +154,16 @@ exports.filterPaths = filterPaths;
 function filterPathsImpl(paths, patterns) {
     return (patterns === null || patterns === void 0 ? void 0 : patterns.length) === 0
         ? paths
-        : paths.filter(path => {
-            return patterns.reduce((prevResult, pattern) => {
-                return pattern.startsWith(NEGATION)
-                    ? prevResult && !match(path, pattern.substring(1))
-                    : prevResult || match(path, pattern);
-            }, false);
-        });
+        : paths.filter(path => testPath(path, patterns));
 }
+function testPath(path, patterns) {
+    return patterns.reduce((prevResult, pattern) => {
+        return pattern.startsWith(NEGATION)
+            ? prevResult && !match(path, pattern.substring(1))
+            : prevResult || match(path, pattern);
+    }, false);
+}
+exports.testPath = testPath;
 
 
 /***/ }),
@@ -260,12 +261,12 @@ function getChangedFilesImpl(token) {
                 core.setFailed('Getting changed files only works on pull request events.');
                 return [];
             }
-            const files = yield octokit.paginate(octokit.rest.pulls.listFiles, {
+            const entries = yield octokit.paginate(octokit.rest.pulls.listFiles, {
                 owner: github_1.context.repo.owner,
                 repo: github_1.context.repo.repo,
                 pull_number: github_1.context.payload.pull_request.number,
             });
-            return files.map(file => file.filename);
+            return entries.map(({ filename, status }) => ({ filename, status }));
         }
         catch (error) {
             core.setFailed(`Getting changed files failed with error: ${error}`);
@@ -574,11 +575,14 @@ function run() {
             const output = core.getInput(common_1.inputs.OUTPUT, { required: true });
             console.log('patterns: ' + JSON.stringify(pathPatterns, undefined, 2));
             const changedFiles = yield (0, common_1.getChangedFiles)(token);
-            const filteredFiles = (0, common_1.filterPaths)(changedFiles, pathPatterns);
+            const filteredFiles = pathPatterns.length > 0
+                ? changedFiles.filter(({ filename }) => (0, common_1.testPath)(filename, pathPatterns))
+                : changedFiles;
             (0, common_1.ensureDir)(output);
-            fs.writeFileSync(output, JSON.stringify(filteredFiles.map(filename => ({ filename })), undefined, 2));
+            fs.writeFileSync(output, JSON.stringify(filteredFiles.map(({ filename }) => ({ filename })), undefined, 2));
             (0, common_1.setOutputs)({
-                files: filteredFiles,
+                json: JSON.stringify(filteredFiles, undefined, 2),
+                files: filteredFiles.map(e => e.filename),
                 count: filteredFiles.length,
             });
         }

--- a/get-changed-files/dist/index.js
+++ b/get-changed-files/dist/index.js
@@ -581,10 +581,10 @@ function run() {
             (0, common_1.ensureDir)(output);
             fs.writeFileSync(output, JSON.stringify(filteredFiles.map(({ path }) => ({ filename: path })), undefined, 2));
             (0, common_1.setOutputs)({
-                json: {
-                    files: JSON.stringify(filteredFiles, undefined, 2),
+                json: JSON.stringify({
+                    files: filteredFiles,
                     count: filteredFiles.length,
-                },
+                }),
                 files: filteredFiles.map(e => e.path),
                 count: filteredFiles.length,
             });

--- a/get-changed-files/dist/index.js
+++ b/get-changed-files/dist/index.js
@@ -49,7 +49,6 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.outputs = exports.inputs = void 0;
 exports.inputs = {
     GH_TOKEN: 'gh-token',
-    OUTPUT: 'output',
     PATHS: 'paths',
 };
 exports.outputs = {
@@ -564,7 +563,6 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const fs = __importStar(__nccwpck_require__(7147));
 const core = __importStar(__nccwpck_require__(5316));
 const common_1 = __nccwpck_require__(9145);
 function run() {
@@ -572,14 +570,11 @@ function run() {
         try {
             const pathPatterns = core.getInput(common_1.inputs.PATHS).split(';');
             const token = core.getInput(common_1.inputs.GH_TOKEN, { required: true });
-            const output = core.getInput(common_1.inputs.OUTPUT, { required: true });
             console.log('patterns: ' + JSON.stringify(pathPatterns, undefined, 2));
             const changedFiles = yield (0, common_1.getChangedFiles)(token);
             const filteredFiles = pathPatterns.length > 0
                 ? changedFiles.filter(({ path }) => (0, common_1.testPath)(path, pathPatterns))
                 : changedFiles;
-            (0, common_1.ensureDir)(output);
-            fs.writeFileSync(output, JSON.stringify(filteredFiles.map(({ path }) => ({ filename: path })), undefined, 2));
             (0, common_1.setOutputs)({
                 json: JSON.stringify({
                     files: filteredFiles,

--- a/get-changed-files/dist/index.js
+++ b/get-changed-files/dist/index.js
@@ -530,6 +530,8 @@ function run() {
             const filteredFiles = (0, common_1.filterPaths)(changedFiles, pathPatterns);
             (0, common_1.ensureDir)(output);
             fs.writeFileSync(output, JSON.stringify(filteredFiles.map(filename => ({ filename })), undefined, 2));
+            core.setOutput('files', filteredFiles.toString().trim());
+            core.setOutput('count', filteredFiles.length.toString().trim());
         }
         catch (error) {
             if (error instanceof Error) {

--- a/get-changed-files/dist/index.js
+++ b/get-changed-files/dist/index.js
@@ -16,8 +16,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.execCommand = void 0;
+exports.setOutputs = exports.execCommand = void 0;
+const core_1 = __nccwpck_require__(5316);
 const exec_1 = __nccwpck_require__(110);
+const serialization_utils_1 = __nccwpck_require__(9091);
 function execCommand(command) {
     return __awaiter(this, void 0, void 0, function* () {
         const { stdout, stderr, exitCode } = yield (0, exec_1.getExecOutput)(command);
@@ -28,6 +30,13 @@ function execCommand(command) {
     });
 }
 exports.execCommand = execCommand;
+function setOutputs(values) {
+    (0, core_1.setOutput)('json', JSON.stringify(values));
+    for (const [key, value] of Object.entries(values)) {
+        (0, core_1.setOutput)(key, (0, serialization_utils_1.stringifyForShell)(value));
+    }
+}
+exports.setOutputs = setOutputs;
 
 
 /***/ }),
@@ -264,6 +273,44 @@ function getChangedFilesImpl(token) {
         }
     });
 }
+
+
+/***/ }),
+
+/***/ 9091:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.stringifyForShell = void 0;
+function stringifyArrayItem(item) {
+    switch (typeof item) {
+        case 'number':
+            return item.toString();
+        case 'string':
+            return `'${item}'`;
+        default:
+            return JSON.stringify(item);
+    }
+}
+function stringifyForShell(value) {
+    switch (typeof value) {
+        case 'string':
+            return value;
+        case 'object':
+            if (Array.isArray(value)) {
+                return value.map(stringifyArrayItem).join(' ');
+            }
+            if (value === null) {
+                return '';
+            }
+            return value.toString();
+        default:
+            return JSON.stringify(value);
+    }
+}
+exports.stringifyForShell = stringifyForShell;
 
 
 /***/ }),
@@ -530,12 +577,10 @@ function run() {
             const filteredFiles = (0, common_1.filterPaths)(changedFiles, pathPatterns);
             (0, common_1.ensureDir)(output);
             fs.writeFileSync(output, JSON.stringify(filteredFiles.map(filename => ({ filename })), undefined, 2));
-            core.setOutput('files', JSON.stringify(filteredFiles));
-            core.setOutput('json', JSON.stringify({
+            (0, common_1.setOutputs)({
                 files: filteredFiles,
                 count: filteredFiles.length,
-            }));
-            core.setOutput('count', filteredFiles.length.toString().trim());
+            });
         }
         catch (error) {
             if (error instanceof Error) {

--- a/get-changed-files/dist/index.js
+++ b/get-changed-files/dist/index.js
@@ -530,7 +530,11 @@ function run() {
             const filteredFiles = (0, common_1.filterPaths)(changedFiles, pathPatterns);
             (0, common_1.ensureDir)(output);
             fs.writeFileSync(output, JSON.stringify(filteredFiles.map(filename => ({ filename })), undefined, 2));
-            core.setOutput('files', filteredFiles.toString().trim());
+            core.setOutput('files', JSON.stringify(filteredFiles));
+            core.setOutput('json', JSON.stringify({
+                files: filteredFiles,
+                count: filteredFiles.length,
+            }));
             core.setOutput('count', filteredFiles.length.toString().trim());
         }
         catch (error) {

--- a/get-changed-files/src/main.ts
+++ b/get-changed-files/src/main.ts
@@ -17,6 +17,9 @@ async function run(): Promise<void> {
 
         ensureDir(output);
         fs.writeFileSync(output, JSON.stringify(filteredFiles.map(filename => ({ filename })), undefined, 2));
+
+        core.setOutput('files', filteredFiles.toString().trim());
+        core.setOutput('count', filteredFiles.length.toString().trim());
     } catch (error) {
         if (error instanceof Error) {
             core.setFailed(error.message)

--- a/get-changed-files/src/main.ts
+++ b/get-changed-files/src/main.ts
@@ -14,7 +14,6 @@ async function run(): Promise<void> {
     try {
         const pathPatterns = core.getInput(inputs.PATHS).split(';');
         const token = core.getInput(inputs.GH_TOKEN, { required: true });
-        const output = core.getInput(inputs.OUTPUT, { required: true });
 
         console.log('patterns: ' + JSON.stringify(pathPatterns, undefined, 2));
 
@@ -22,9 +21,6 @@ async function run(): Promise<void> {
         const filteredFiles = pathPatterns.length > 0
             ? changedFiles.filter(({ path }) => testPath(path, pathPatterns))
             : changedFiles;
-
-        ensureDir(output);
-        fs.writeFileSync(output, JSON.stringify(filteredFiles.map(({ path }) => ({ filename: path })), undefined, 2));
 
         setOutputs({
             json: JSON.stringify({

--- a/get-changed-files/src/main.ts
+++ b/get-changed-files/src/main.ts
@@ -20,15 +20,18 @@ async function run(): Promise<void> {
 
         const changedFiles = await getChangedFiles(token);
         const filteredFiles = pathPatterns.length > 0
-            ? changedFiles.filter(({ filename }) => testPath(filename, pathPatterns))
+            ? changedFiles.filter(({ path }) => testPath(path, pathPatterns))
             : changedFiles;
 
         ensureDir(output);
-        fs.writeFileSync(output, JSON.stringify(filteredFiles.map(({ filename }) => ({ filename })), undefined, 2));
+        fs.writeFileSync(output, JSON.stringify(filteredFiles.map(({ path }) => ({ filename: path })), undefined, 2));
 
         setOutputs({
-            json: JSON.stringify(filteredFiles, undefined, 2),
-            files: filteredFiles.map(e => e.filename),
+            json: {
+                files: JSON.stringify(filteredFiles, undefined, 2),
+                count: filteredFiles.length,
+            },
+            files: filteredFiles.map(e => e.path),
             count: filteredFiles.length,
         });
     } catch (error) {

--- a/get-changed-files/src/main.ts
+++ b/get-changed-files/src/main.ts
@@ -27,10 +27,10 @@ async function run(): Promise<void> {
         fs.writeFileSync(output, JSON.stringify(filteredFiles.map(({ path }) => ({ filename: path })), undefined, 2));
 
         setOutputs({
-            json: {
-                files: JSON.stringify(filteredFiles, undefined, 2),
+            json: JSON.stringify({
+                files: filteredFiles,
                 count: filteredFiles.length,
-            },
+            }),
             files: filteredFiles.map(e => e.path),
             count: filteredFiles.length,
         });

--- a/get-changed-files/src/main.ts
+++ b/get-changed-files/src/main.ts
@@ -1,7 +1,13 @@
 import * as fs from 'fs';
 import * as core from '@actions/core';
 
-import { inputs, filterPaths, getChangedFiles, ensureDir } from 'common';
+import {
+    inputs,
+    filterPaths,
+    getChangedFiles,
+    ensureDir,
+    setOutputs,
+} from 'common';
 
 
 async function run(): Promise<void> {
@@ -18,12 +24,10 @@ async function run(): Promise<void> {
         ensureDir(output);
         fs.writeFileSync(output, JSON.stringify(filteredFiles.map(filename => ({ filename })), undefined, 2));
 
-        core.setOutput('files', JSON.stringify(filteredFiles));
-        core.setOutput('json', JSON.stringify({
+        setOutputs({
             files: filteredFiles,
             count: filteredFiles.length,
-        }));
-        core.setOutput('count', filteredFiles.length.toString().trim());
+        });
     } catch (error) {
         if (error instanceof Error) {
             core.setFailed(error.message)

--- a/get-changed-files/src/main.ts
+++ b/get-changed-files/src/main.ts
@@ -18,7 +18,11 @@ async function run(): Promise<void> {
         ensureDir(output);
         fs.writeFileSync(output, JSON.stringify(filteredFiles.map(filename => ({ filename })), undefined, 2));
 
-        core.setOutput('files', filteredFiles.toString().trim());
+        core.setOutput('files', JSON.stringify(filteredFiles));
+        core.setOutput('json', JSON.stringify({
+            files: filteredFiles,
+            count: filteredFiles.length,
+        }));
         core.setOutput('count', filteredFiles.length.toString().trim());
     } catch (error) {
         if (error instanceof Error) {

--- a/get-changed-files/src/main.ts
+++ b/get-changed-files/src/main.ts
@@ -3,10 +3,10 @@ import * as core from '@actions/core';
 
 import {
     inputs,
-    filterPaths,
     getChangedFiles,
     ensureDir,
     setOutputs,
+    testPath,
 } from 'common';
 
 
@@ -19,13 +19,16 @@ async function run(): Promise<void> {
         console.log('patterns: ' + JSON.stringify(pathPatterns, undefined, 2));
 
         const changedFiles = await getChangedFiles(token);
-        const filteredFiles = filterPaths(changedFiles, pathPatterns);
+        const filteredFiles = pathPatterns.length > 0
+            ? changedFiles.filter(({ filename }) => testPath(filename, pathPatterns))
+            : changedFiles;
 
         ensureDir(output);
-        fs.writeFileSync(output, JSON.stringify(filteredFiles.map(filename => ({ filename })), undefined, 2));
+        fs.writeFileSync(output, JSON.stringify(filteredFiles.map(({ filename }) => ({ filename })), undefined, 2));
 
         setOutputs({
-            files: filteredFiles,
+            json: JSON.stringify(filteredFiles, undefined, 2),
+            files: filteredFiles.map(e => e.filename),
             count: filteredFiles.length,
         });
     } catch (error) {

--- a/pr-filter/dist/index.js
+++ b/pr-filter/dist/index.js
@@ -144,13 +144,15 @@ function filterPaths(paths, patterns) {
 }
 exports.filterPaths = filterPaths;
 function filterPathsImpl(paths, patterns) {
-    return paths.filter(path => {
-        return patterns.reduce((prevResult, pattern) => {
-            return pattern.startsWith(NEGATION)
-                ? prevResult && !match(path, pattern.substring(1))
-                : prevResult || match(path, pattern);
-        }, false);
-    });
+    return (patterns === null || patterns === void 0 ? void 0 : patterns.length) === 0
+        ? paths
+        : paths.filter(path => {
+            return patterns.reduce((prevResult, pattern) => {
+                return pattern.startsWith(NEGATION)
+                    ? prevResult && !match(path, pattern.substring(1))
+                    : prevResult || match(path, pattern);
+            }, false);
+        });
 }
 
 

--- a/pr-filter/dist/index.js
+++ b/pr-filter/dist/index.js
@@ -16,8 +16,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.execCommand = void 0;
+exports.setOutputs = exports.execCommand = void 0;
+const core_1 = __nccwpck_require__(5316);
 const exec_1 = __nccwpck_require__(110);
+const serialization_utils_1 = __nccwpck_require__(9091);
 function execCommand(command) {
     return __awaiter(this, void 0, void 0, function* () {
         const { stdout, stderr, exitCode } = yield (0, exec_1.getExecOutput)(command);
@@ -28,6 +30,13 @@ function execCommand(command) {
     });
 }
 exports.execCommand = execCommand;
+function setOutputs(values) {
+    (0, core_1.setOutput)('json', JSON.stringify(values));
+    for (const [key, value] of Object.entries(values)) {
+        (0, core_1.setOutput)(key, (0, serialization_utils_1.stringifyForShell)(value));
+    }
+}
+exports.setOutputs = setOutputs;
 
 
 /***/ }),
@@ -264,6 +273,44 @@ function getChangedFilesImpl(token) {
         }
     });
 }
+
+
+/***/ }),
+
+/***/ 9091:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.stringifyForShell = void 0;
+function stringifyArrayItem(item) {
+    switch (typeof item) {
+        case 'number':
+            return item.toString();
+        case 'string':
+            return `'${item}'`;
+        default:
+            return JSON.stringify(item);
+    }
+}
+function stringifyForShell(value) {
+    switch (typeof value) {
+        case 'string':
+            return value;
+        case 'object':
+            if (Array.isArray(value)) {
+                return value.map(stringifyArrayItem).join(' ');
+            }
+            if (value === null) {
+                return '';
+            }
+            return value.toString();
+        default:
+            return JSON.stringify(value);
+    }
+}
+exports.stringifyForShell = stringifyForShell;
 
 
 /***/ }),

--- a/pr-filter/dist/index.js
+++ b/pr-filter/dist/index.js
@@ -266,7 +266,7 @@ function getChangedFilesImpl(token) {
                 repo: github_1.context.repo.repo,
                 pull_number: github_1.context.payload.pull_request.number,
             });
-            return entries.map(({ filename, status }) => ({ filename, status }));
+            return entries.map(({ filename, status }) => ({ path: filename, status }));
         }
         catch (error) {
             core.setFailed(`Getting changed files failed with error: ${error}`);
@@ -33709,7 +33709,7 @@ function run() {
         try {
             const pathPatterns = core.getInput(common_1.inputs.PATHS).split(';');
             const token = core.getInput(common_1.inputs.GH_TOKEN, { required: true });
-            const changedFiles = (yield (0, common_1.getChangedFiles)(token)).map(e => e.filename);
+            const changedFiles = (yield (0, common_1.getChangedFiles)(token)).map(e => e.path);
             const filteredFiles = (0, common_1.filterPaths)(changedFiles, pathPatterns);
             core.setOutput(common_1.outputs.RESULT, filteredFiles.length > 0);
         }

--- a/pr-filter/dist/index.js
+++ b/pr-filter/dist/index.js
@@ -49,7 +49,6 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.outputs = exports.inputs = void 0;
 exports.inputs = {
     GH_TOKEN: 'gh-token',
-    OUTPUT: 'output',
     PATHS: 'paths',
 };
 exports.outputs = {

--- a/pr-filter/dist/index.js
+++ b/pr-filter/dist/index.js
@@ -31,7 +31,6 @@ function execCommand(command) {
 }
 exports.execCommand = execCommand;
 function setOutputs(values) {
-    (0, core_1.setOutput)('json', JSON.stringify(values));
     for (const [key, value] of Object.entries(values)) {
         (0, core_1.setOutput)(key, (0, serialization_utils_1.stringifyForShell)(value));
     }
@@ -135,7 +134,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.filterPaths = void 0;
+exports.testPath = exports.filterPaths = void 0;
 const core = __importStar(__nccwpck_require__(5316));
 const minimatch_1 = __nccwpck_require__(148);
 const NEGATION = '!';
@@ -155,14 +154,16 @@ exports.filterPaths = filterPaths;
 function filterPathsImpl(paths, patterns) {
     return (patterns === null || patterns === void 0 ? void 0 : patterns.length) === 0
         ? paths
-        : paths.filter(path => {
-            return patterns.reduce((prevResult, pattern) => {
-                return pattern.startsWith(NEGATION)
-                    ? prevResult && !match(path, pattern.substring(1))
-                    : prevResult || match(path, pattern);
-            }, false);
-        });
+        : paths.filter(path => testPath(path, patterns));
 }
+function testPath(path, patterns) {
+    return patterns.reduce((prevResult, pattern) => {
+        return pattern.startsWith(NEGATION)
+            ? prevResult && !match(path, pattern.substring(1))
+            : prevResult || match(path, pattern);
+    }, false);
+}
+exports.testPath = testPath;
 
 
 /***/ }),
@@ -260,12 +261,12 @@ function getChangedFilesImpl(token) {
                 core.setFailed('Getting changed files only works on pull request events.');
                 return [];
             }
-            const files = yield octokit.paginate(octokit.rest.pulls.listFiles, {
+            const entries = yield octokit.paginate(octokit.rest.pulls.listFiles, {
                 owner: github_1.context.repo.owner,
                 repo: github_1.context.repo.repo,
                 pull_number: github_1.context.payload.pull_request.number,
             });
-            return files.map(file => file.filename);
+            return entries.map(({ filename, status }) => ({ filename, status }));
         }
         catch (error) {
             core.setFailed(`Getting changed files failed with error: ${error}`);
@@ -33708,7 +33709,7 @@ function run() {
         try {
             const pathPatterns = core.getInput(common_1.inputs.PATHS).split(';');
             const token = core.getInput(common_1.inputs.GH_TOKEN, { required: true });
-            const changedFiles = yield (0, common_1.getChangedFiles)(token);
+            const changedFiles = (yield (0, common_1.getChangedFiles)(token)).map(e => e.filename);
             const filteredFiles = (0, common_1.filterPaths)(changedFiles, pathPatterns);
             core.setOutput(common_1.outputs.RESULT, filteredFiles.length > 0);
         }

--- a/pr-filter/src/main.ts
+++ b/pr-filter/src/main.ts
@@ -7,7 +7,7 @@ async function run(): Promise<void> {
         const pathPatterns = core.getInput(inputs.PATHS).split(';');
         const token = core.getInput(inputs.GH_TOKEN, { required: true });
 
-        const changedFiles = (await getChangedFiles(token)).map(e => e.filename);
+        const changedFiles = (await getChangedFiles(token)).map(e => e.path);
         const filteredFiles = filterPaths(changedFiles, pathPatterns);
 
         core.setOutput(outputs.RESULT, filteredFiles.length > 0);

--- a/pr-filter/src/main.ts
+++ b/pr-filter/src/main.ts
@@ -7,7 +7,7 @@ async function run(): Promise<void> {
         const pathPatterns = core.getInput(inputs.PATHS).split(';');
         const token = core.getInput(inputs.GH_TOKEN, { required: true });
 
-        const changedFiles = await getChangedFiles(token);
+        const changedFiles = (await getChangedFiles(token)).map(e => e.filename);
         const filteredFiles = filterPaths(changedFiles, pathPatterns);
 
         core.setOutput(outputs.RESULT, filteredFiles.length > 0);

--- a/verify-version-change/dist/index.js
+++ b/verify-version-change/dist/index.js
@@ -144,13 +144,15 @@ function filterPaths(paths, patterns) {
 }
 exports.filterPaths = filterPaths;
 function filterPathsImpl(paths, patterns) {
-    return paths.filter(path => {
-        return patterns.reduce((prevResult, pattern) => {
-            return pattern.startsWith(NEGATION)
-                ? prevResult && !match(path, pattern.substring(1))
-                : prevResult || match(path, pattern);
-        }, false);
-    });
+    return (patterns === null || patterns === void 0 ? void 0 : patterns.length) === 0
+        ? paths
+        : paths.filter(path => {
+            return patterns.reduce((prevResult, pattern) => {
+                return pattern.startsWith(NEGATION)
+                    ? prevResult && !match(path, pattern.substring(1))
+                    : prevResult || match(path, pattern);
+            }, false);
+        });
 }
 
 

--- a/verify-version-change/dist/index.js
+++ b/verify-version-change/dist/index.js
@@ -16,8 +16,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.execCommand = void 0;
+exports.setOutputs = exports.execCommand = void 0;
+const core_1 = __nccwpck_require__(5316);
 const exec_1 = __nccwpck_require__(110);
+const serialization_utils_1 = __nccwpck_require__(9091);
 function execCommand(command) {
     return __awaiter(this, void 0, void 0, function* () {
         const { stdout, stderr, exitCode } = yield (0, exec_1.getExecOutput)(command);
@@ -28,6 +30,13 @@ function execCommand(command) {
     });
 }
 exports.execCommand = execCommand;
+function setOutputs(values) {
+    (0, core_1.setOutput)('json', JSON.stringify(values));
+    for (const [key, value] of Object.entries(values)) {
+        (0, core_1.setOutput)(key, (0, serialization_utils_1.stringifyForShell)(value));
+    }
+}
+exports.setOutputs = setOutputs;
 
 
 /***/ }),
@@ -264,6 +273,44 @@ function getChangedFilesImpl(token) {
         }
     });
 }
+
+
+/***/ }),
+
+/***/ 9091:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.stringifyForShell = void 0;
+function stringifyArrayItem(item) {
+    switch (typeof item) {
+        case 'number':
+            return item.toString();
+        case 'string':
+            return `'${item}'`;
+        default:
+            return JSON.stringify(item);
+    }
+}
+function stringifyForShell(value) {
+    switch (typeof value) {
+        case 'string':
+            return value;
+        case 'object':
+            if (Array.isArray(value)) {
+                return value.map(stringifyArrayItem).join(' ');
+            }
+            if (value === null) {
+                return '';
+            }
+            return value.toString();
+        default:
+            return JSON.stringify(value);
+    }
+}
+exports.stringifyForShell = stringifyForShell;
 
 
 /***/ }),

--- a/verify-version-change/dist/index.js
+++ b/verify-version-change/dist/index.js
@@ -49,7 +49,6 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.outputs = exports.inputs = void 0;
 exports.inputs = {
     GH_TOKEN: 'gh-token',
-    OUTPUT: 'output',
     PATHS: 'paths',
 };
 exports.outputs = {

--- a/verify-version-change/dist/index.js
+++ b/verify-version-change/dist/index.js
@@ -266,7 +266,7 @@ function getChangedFilesImpl(token) {
                 repo: github_1.context.repo.repo,
                 pull_number: github_1.context.payload.pull_request.number,
             });
-            return entries.map(({ filename, status }) => ({ filename, status }));
+            return entries.map(({ filename, status }) => ({ path: filename, status }));
         }
         catch (error) {
             core.setFailed(`Getting changed files failed with error: ${error}`);


### PR DESCRIPTION
### Practical Value
The `paths` is not required, but if not specified, empty list of files returned.

### Before
```yaml
    - uses: DevExpress/github-actions/get-changed-files@v1
      with:
        gh-token: XXX
        paths: '**/*'
        output: XXX
```

### After
```yaml
    - uses: DevExpress/github-actions/get-changed-files@v1
      with:
        gh-token: XXX
        output: XXX
```

