### PR TITLE
Update get-changed-files action

### DIFF
--- a/common/src/common-utils.ts
+++ b/common/src/common-utils.ts
@@ -1,4 +1,6 @@
+import { setOutput } from '@actions/core';
 import { getExecOutput } from '@actions/exec'
+import { stringifyForShell } from './serialization-utils';
 
 export async function execCommand(command: string): Promise<string> {
   const { stdout, stderr, exitCode } = await getExecOutput(command)
@@ -8,4 +10,10 @@ export async function execCommand(command: string): Promise<string> {
   }
 
   return stdout.trim()
+}
+
+export function setOutputs(values: Record<string, unknown>): void {
+  for (const [key, value] of Object.entries(values)) {
+    setOutput(key, stringifyForShell(value));
+  }
 }

--- a/common/src/constants.ts
+++ b/common/src/constants.ts
@@ -1,7 +1,6 @@
 
 export const inputs = {
     GH_TOKEN: 'gh-token',
-    OUTPUT: 'output',
     PATHS: 'paths',
 } as const;
 

--- a/common/src/path-utils.test.ts
+++ b/common/src/path-utils.test.ts
@@ -11,6 +11,11 @@ describe('path utils', () => {
             },
             {
                 paths: ['a.ts', 'a.js', 'b.md'],
+                patterns: [],
+                expected: ['a.ts', 'a.js', 'b.md']
+            },
+            {
+                paths: ['a.ts', 'a.js', 'b.md'],
                 patterns: ['b*.*'],
                 expected: ['b.md']
             },

--- a/common/src/path-utils.test.ts
+++ b/common/src/path-utils.test.ts
@@ -1,4 +1,4 @@
-import { filterPaths } from "./path-utils";
+import { filterPaths, normalizePatterns } from "./path-utils";
 
 describe('path utils', () => {
 
@@ -92,6 +92,20 @@ describe('path utils', () => {
             },
         ])('specific cases [%#]', ({ paths, patterns, expected }) => {
             expect(filterPaths(paths, patterns)).toEqual(expected);
+        });
+    });
+
+    describe('normalizePatterns', () => {
+        test.each([
+            { patterns: undefined, expected: undefined },
+            { patterns: [ ], expected: undefined },
+            { patterns: [ undefined ], expected: undefined },
+            { patterns: [ '' ], expected: undefined },
+            { patterns: [ '', undefined ], expected: undefined },
+            { patterns: ['a'], expected: ['a'] },
+            { patterns: ['', 'a', undefined ], expected: ['a'] },
+        ])('basic cases [%#]', ({ patterns, expected }) => {
+            expect(normalizePatterns(patterns)).toEqual(expected);
         });
     });
 });

--- a/common/src/path-utils.ts
+++ b/common/src/path-utils.ts
@@ -24,13 +24,23 @@ function filterPathsImpl(
     paths: string[],
     patterns: string[],
 ): string[] {
-    return patterns?.length === 0
+    const normalizedPatterns = normalizePatterns(patterns);
+    return normalizedPatterns === undefined
         ? paths
-        : paths.filter(path => {
-            return patterns.reduce((prevResult, pattern) => {
-                return pattern.startsWith(NEGATION)
-                    ? prevResult && !match(path, pattern.substring(1))
-                    : prevResult || match(path, pattern);
-            }, false);
-        });
+        : paths.filter(path => testPath(path, normalizedPatterns));
+}
+
+export function normalizePatterns(patterns?: (string | undefined)[]): string[] | undefined {
+    if(!patterns) return undefined;
+
+    const notEmptyPatterns = patterns.filter(p => p != undefined && p.length > 0);
+    return (notEmptyPatterns.length > 0 ? notEmptyPatterns : undefined) as ReturnType<typeof normalizePatterns>;
+}
+
+export function testPath(path: string, patterns: string[]): boolean {
+    return patterns.reduce((prevResult, pattern) => {
+        return pattern.startsWith(NEGATION)
+            ? prevResult && !match(path, pattern.substring(1))
+            : prevResult || match(path, pattern);
+    }, false);
 }

--- a/common/src/path-utils.ts
+++ b/common/src/path-utils.ts
@@ -24,11 +24,13 @@ function filterPathsImpl(
     paths: string[],
     patterns: string[],
 ): string[] {
-    return paths.filter(path => {
-        return patterns.reduce((prevResult, pattern) => {
-            return pattern.startsWith(NEGATION)
-                ? prevResult && !match(path, pattern.substring(1))
-                : prevResult || match(path, pattern);
-        }, false);
-    });
+    return patterns?.length === 0
+        ? paths
+        : paths.filter(path => {
+            return patterns.reduce((prevResult, pattern) => {
+                return pattern.startsWith(NEGATION)
+                    ? prevResult && !match(path, pattern.substring(1))
+                    : prevResult || match(path, pattern);
+            }, false);
+        });
 }

--- a/common/src/serialization-utils.test.ts
+++ b/common/src/serialization-utils.test.ts
@@ -1,0 +1,23 @@
+import { stringifyForShell } from "./serialization-utils";
+
+describe('action utils', () => {
+
+  describe(stringifyForShell.name, () => {
+    test.each([
+      { value: 123, expected: '123' },
+      { value: 'abc', expected: 'abc' },
+    ])('scalar cases [%#]', ({ value, expected }) => {
+      expect(stringifyForShell(value)).toEqual(expected);
+    });
+  });
+
+  describe(stringifyForShell.name, () => {
+    test.each([
+      { value: [123, 456], expected: '123 456' },
+      { value: ['abc', 'def'], expected: '\'abc\' \'def\'' },
+    ])('array values [%#]', ({ value, expected }) => {
+      expect(stringifyForShell(value)).toEqual(expected);
+    });
+  });
+
+});

--- a/common/src/serialization-utils.ts
+++ b/common/src/serialization-utils.ts
@@ -1,0 +1,35 @@
+function stringifyArrayItem(item: unknown): string {
+  switch (typeof item) {
+    case 'number':
+      return item.toString();
+
+    case 'string':
+      return `'${item}'`;
+
+    default:
+      return JSON.stringify(item);
+  }
+}
+
+export function stringifyForShell(value: unknown): string {
+
+  switch (typeof value) {
+
+    case 'string':
+      return value;
+
+    case 'object':
+      if (Array.isArray(value)) {
+        return value.map(stringifyArrayItem).join(' ');
+      }
+
+      if (value === null) {
+        return '';
+      }
+
+      return value.toString();
+
+    default:
+      return JSON.stringify(value);
+  }
+}

--- a/get-changed-files/action.yml
+++ b/get-changed-files/action.yml
@@ -11,11 +11,6 @@ inputs:
     description: Semicolon separated globs
     required: false
 
-  output:
-    description: Output file path
-    required: true
-
-
 runs:
   using: node16
   main: dist/index.js

--- a/get-changed-files/action.yml
+++ b/get-changed-files/action.yml
@@ -21,5 +21,11 @@ runs:
   main: dist/index.js
 
 outputs:
-  result:
-    description: A file with the list of files in JSON format
+  count:
+    description: The count of all files changed in the PR
+  files:
+    description: Space-separated list of all files changed in the PR
+  json:
+    description: |
+      Full output in JSON format.
+      'Schema: { files: { path: string; status: string; } []; count: number; }'

--- a/get-changed-files/dist/index.js
+++ b/get-changed-files/dist/index.js
@@ -144,13 +144,15 @@ function filterPaths(paths, patterns) {
 }
 exports.filterPaths = filterPaths;
 function filterPathsImpl(paths, patterns) {
-    return paths.filter(path => {
-        return patterns.reduce((prevResult, pattern) => {
-            return pattern.startsWith(NEGATION)
-                ? prevResult && !match(path, pattern.substring(1))
-                : prevResult || match(path, pattern);
-        }, false);
-    });
+    return (patterns === null || patterns === void 0 ? void 0 : patterns.length) === 0
+        ? paths
+        : paths.filter(path => {
+            return patterns.reduce((prevResult, pattern) => {
+                return pattern.startsWith(NEGATION)
+                    ? prevResult && !match(path, pattern.substring(1))
+                    : prevResult || match(path, pattern);
+            }, false);
+        });
 }
 
 

--- a/get-changed-files/dist/index.js
+++ b/get-changed-files/dist/index.js
@@ -16,8 +16,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.execCommand = void 0;
+exports.setOutputs = exports.execCommand = void 0;
+const core_1 = __nccwpck_require__(5316);
 const exec_1 = __nccwpck_require__(110);
+const serialization_utils_1 = __nccwpck_require__(9091);
 function execCommand(command) {
     return __awaiter(this, void 0, void 0, function* () {
         const { stdout, stderr, exitCode } = yield (0, exec_1.getExecOutput)(command);
@@ -28,6 +30,12 @@ function execCommand(command) {
     });
 }
 exports.execCommand = execCommand;
+function setOutputs(values) {
+    for (const [key, value] of Object.entries(values)) {
+        (0, core_1.setOutput)(key, (0, serialization_utils_1.stringifyForShell)(value));
+    }
+}
+exports.setOutputs = setOutputs;
 
 
 /***/ }),
@@ -126,7 +134,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.filterPaths = void 0;
+exports.testPath = exports.normalizePatterns = exports.filterPaths = void 0;
 const core = __importStar(__nccwpck_require__(5316));
 const minimatch_1 = __nccwpck_require__(148);
 const NEGATION = '!';
@@ -144,16 +152,26 @@ function filterPaths(paths, patterns) {
 }
 exports.filterPaths = filterPaths;
 function filterPathsImpl(paths, patterns) {
-    return (patterns === null || patterns === void 0 ? void 0 : patterns.length) === 0
+    const normalizedPatterns = normalizePatterns(patterns);
+    return normalizedPatterns === undefined
         ? paths
-        : paths.filter(path => {
-            return patterns.reduce((prevResult, pattern) => {
-                return pattern.startsWith(NEGATION)
-                    ? prevResult && !match(path, pattern.substring(1))
-                    : prevResult || match(path, pattern);
-            }, false);
-        });
+        : paths.filter(path => testPath(path, normalizedPatterns));
 }
+function normalizePatterns(patterns) {
+    if (!patterns)
+        return undefined;
+    const notEmptyPatterns = patterns.filter(p => p != undefined && p.length > 0);
+    return (notEmptyPatterns.length > 0 ? notEmptyPatterns : undefined);
+}
+exports.normalizePatterns = normalizePatterns;
+function testPath(path, patterns) {
+    return patterns.reduce((prevResult, pattern) => {
+        return pattern.startsWith(NEGATION)
+            ? prevResult && !match(path, pattern.substring(1))
+            : prevResult || match(path, pattern);
+    }, false);
+}
+exports.testPath = testPath;
 
 
 /***/ }),
@@ -251,12 +269,12 @@ function getChangedFilesImpl(token) {
                 core.setFailed('Getting changed files only works on pull request events.');
                 return [];
             }
-            const files = yield octokit.paginate(octokit.rest.pulls.listFiles, {
+            const entries = yield octokit.paginate(octokit.rest.pulls.listFiles, {
                 owner: github_1.context.repo.owner,
                 repo: github_1.context.repo.repo,
                 pull_number: github_1.context.payload.pull_request.number,
             });
-            return files.map(file => file.filename);
+            return entries.map(({ filename, status }) => ({ path: filename, status }));
         }
         catch (error) {
             core.setFailed(`Getting changed files failed with error: ${error}`);
@@ -264,6 +282,44 @@ function getChangedFilesImpl(token) {
         }
     });
 }
+
+
+/***/ }),
+
+/***/ 9091:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.stringifyForShell = void 0;
+function stringifyArrayItem(item) {
+    switch (typeof item) {
+        case 'number':
+            return item.toString();
+        case 'string':
+            return `'${item}'`;
+        default:
+            return JSON.stringify(item);
+    }
+}
+function stringifyForShell(value) {
+    switch (typeof value) {
+        case 'string':
+            return value;
+        case 'object':
+            if (Array.isArray(value)) {
+                return value.map(stringifyArrayItem).join(' ');
+            }
+            if (value === null) {
+                return '';
+            }
+            return value.toString();
+        default:
+            return JSON.stringify(value);
+    }
+}
+exports.stringifyForShell = stringifyForShell;
 
 
 /***/ }),
@@ -522,14 +578,24 @@ const common_1 = __nccwpck_require__(9145);
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            const pathPatterns = core.getInput(common_1.inputs.PATHS).split(';');
+            const patterns = (0, common_1.normalizePatterns)(core.getInput(common_1.inputs.PATHS).split(';'));
             const token = core.getInput(common_1.inputs.GH_TOKEN, { required: true });
             const output = core.getInput(common_1.inputs.OUTPUT, { required: true });
-            console.log('patterns: ' + JSON.stringify(pathPatterns, undefined, 2));
+            console.log('patterns: ' + JSON.stringify(patterns, undefined, 2));
             const changedFiles = yield (0, common_1.getChangedFiles)(token);
-            const filteredFiles = (0, common_1.filterPaths)(changedFiles, pathPatterns);
+            const filteredFiles = patterns === undefined
+                ? changedFiles
+                : changedFiles.filter(({ path }) => (0, common_1.testPath)(path, patterns));
             (0, common_1.ensureDir)(output);
-            fs.writeFileSync(output, JSON.stringify(filteredFiles.map(filename => ({ filename })), undefined, 2));
+            fs.writeFileSync(output, JSON.stringify(filteredFiles.map(({ path }) => ({ filename: path })), undefined, 2));
+            (0, common_1.setOutputs)({
+                json: JSON.stringify({
+                    files: filteredFiles,
+                    count: filteredFiles.length,
+                }),
+                files: filteredFiles.map(e => e.path),
+                count: filteredFiles.length,
+            });
         }
         catch (error) {
             if (error instanceof Error) {

--- a/get-changed-files/dist/index.js
+++ b/get-changed-files/dist/index.js
@@ -49,7 +49,6 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.outputs = exports.inputs = void 0;
 exports.inputs = {
     GH_TOKEN: 'gh-token',
-    OUTPUT: 'output',
     PATHS: 'paths',
 };
 exports.outputs = {
@@ -572,7 +571,6 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const fs = __importStar(__nccwpck_require__(7147));
 const core = __importStar(__nccwpck_require__(5316));
 const common_1 = __nccwpck_require__(9145);
 function run() {
@@ -580,14 +578,11 @@ function run() {
         try {
             const patterns = (0, common_1.normalizePatterns)(core.getInput(common_1.inputs.PATHS).split(';'));
             const token = core.getInput(common_1.inputs.GH_TOKEN, { required: true });
-            const output = core.getInput(common_1.inputs.OUTPUT, { required: true });
             console.log('patterns: ' + JSON.stringify(patterns, undefined, 2));
             const changedFiles = yield (0, common_1.getChangedFiles)(token);
             const filteredFiles = patterns === undefined
                 ? changedFiles
                 : changedFiles.filter(({ path }) => (0, common_1.testPath)(path, patterns));
-            (0, common_1.ensureDir)(output);
-            fs.writeFileSync(output, JSON.stringify(filteredFiles.map(({ path }) => ({ filename: path })), undefined, 2));
             (0, common_1.setOutputs)({
                 json: JSON.stringify({
                     files: filteredFiles,

--- a/get-changed-files/src/main.ts
+++ b/get-changed-files/src/main.ts
@@ -1,22 +1,40 @@
 import * as fs from 'fs';
 import * as core from '@actions/core';
 
-import { inputs, filterPaths, getChangedFiles, ensureDir } from 'common';
+import {
+    inputs,
+    getChangedFiles,
+    ensureDir,
+    setOutputs,
+    testPath,
+    normalizePatterns,
+} from 'common';
 
 
 async function run(): Promise<void> {
     try {
-        const pathPatterns = core.getInput(inputs.PATHS).split(';');
+        const patterns = normalizePatterns(core.getInput(inputs.PATHS).split(';'));
         const token = core.getInput(inputs.GH_TOKEN, { required: true });
         const output = core.getInput(inputs.OUTPUT, { required: true });
 
-        console.log('patterns: ' + JSON.stringify(pathPatterns, undefined, 2));
+        console.log('patterns: ' + JSON.stringify(patterns, undefined, 2));
 
         const changedFiles = await getChangedFiles(token);
-        const filteredFiles = filterPaths(changedFiles, pathPatterns);
+        const filteredFiles = patterns === undefined
+            ? changedFiles
+            : changedFiles.filter(({ path }) => testPath(path, patterns));
 
         ensureDir(output);
-        fs.writeFileSync(output, JSON.stringify(filteredFiles.map(filename => ({ filename })), undefined, 2));
+        fs.writeFileSync(output, JSON.stringify(filteredFiles.map(({ path }) => ({ filename: path })), undefined, 2));
+
+        setOutputs({
+            json: JSON.stringify({
+                files: filteredFiles,
+                count: filteredFiles.length,
+            }),
+            files: filteredFiles.map(e => e.path),
+            count: filteredFiles.length,
+        });
     } catch (error) {
         if (error instanceof Error) {
             core.setFailed(error.message)

--- a/get-changed-files/src/main.ts
+++ b/get-changed-files/src/main.ts
@@ -1,10 +1,8 @@
-import * as fs from 'fs';
 import * as core from '@actions/core';
 
 import {
     inputs,
     getChangedFiles,
-    ensureDir,
     setOutputs,
     testPath,
     normalizePatterns,
@@ -15,7 +13,6 @@ async function run(): Promise<void> {
     try {
         const patterns = normalizePatterns(core.getInput(inputs.PATHS).split(';'));
         const token = core.getInput(inputs.GH_TOKEN, { required: true });
-        const output = core.getInput(inputs.OUTPUT, { required: true });
 
         console.log('patterns: ' + JSON.stringify(patterns, undefined, 2));
 
@@ -23,9 +20,6 @@ async function run(): Promise<void> {
         const filteredFiles = patterns === undefined
             ? changedFiles
             : changedFiles.filter(({ path }) => testPath(path, patterns));
-
-        ensureDir(output);
-        fs.writeFileSync(output, JSON.stringify(filteredFiles.map(({ path }) => ({ filename: path })), undefined, 2));
 
         setOutputs({
             json: JSON.stringify({

--- a/pr-filter/dist/index.js
+++ b/pr-filter/dist/index.js
@@ -16,8 +16,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.execCommand = void 0;
+exports.setOutputs = exports.execCommand = void 0;
+const core_1 = __nccwpck_require__(5316);
 const exec_1 = __nccwpck_require__(110);
+const serialization_utils_1 = __nccwpck_require__(9091);
 function execCommand(command) {
     return __awaiter(this, void 0, void 0, function* () {
         const { stdout, stderr, exitCode } = yield (0, exec_1.getExecOutput)(command);
@@ -28,6 +30,12 @@ function execCommand(command) {
     });
 }
 exports.execCommand = execCommand;
+function setOutputs(values) {
+    for (const [key, value] of Object.entries(values)) {
+        (0, core_1.setOutput)(key, (0, serialization_utils_1.stringifyForShell)(value));
+    }
+}
+exports.setOutputs = setOutputs;
 
 
 /***/ }),
@@ -126,7 +134,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.filterPaths = void 0;
+exports.testPath = exports.normalizePatterns = exports.filterPaths = void 0;
 const core = __importStar(__nccwpck_require__(5316));
 const minimatch_1 = __nccwpck_require__(148);
 const NEGATION = '!';
@@ -144,16 +152,26 @@ function filterPaths(paths, patterns) {
 }
 exports.filterPaths = filterPaths;
 function filterPathsImpl(paths, patterns) {
-    return (patterns === null || patterns === void 0 ? void 0 : patterns.length) === 0
+    const normalizedPatterns = normalizePatterns(patterns);
+    return normalizedPatterns === undefined
         ? paths
-        : paths.filter(path => {
-            return patterns.reduce((prevResult, pattern) => {
-                return pattern.startsWith(NEGATION)
-                    ? prevResult && !match(path, pattern.substring(1))
-                    : prevResult || match(path, pattern);
-            }, false);
-        });
+        : paths.filter(path => testPath(path, normalizedPatterns));
 }
+function normalizePatterns(patterns) {
+    if (!patterns)
+        return undefined;
+    const notEmptyPatterns = patterns.filter(p => p != undefined && p.length > 0);
+    return (notEmptyPatterns.length > 0 ? notEmptyPatterns : undefined);
+}
+exports.normalizePatterns = normalizePatterns;
+function testPath(path, patterns) {
+    return patterns.reduce((prevResult, pattern) => {
+        return pattern.startsWith(NEGATION)
+            ? prevResult && !match(path, pattern.substring(1))
+            : prevResult || match(path, pattern);
+    }, false);
+}
+exports.testPath = testPath;
 
 
 /***/ }),
@@ -251,12 +269,12 @@ function getChangedFilesImpl(token) {
                 core.setFailed('Getting changed files only works on pull request events.');
                 return [];
             }
-            const files = yield octokit.paginate(octokit.rest.pulls.listFiles, {
+            const entries = yield octokit.paginate(octokit.rest.pulls.listFiles, {
                 owner: github_1.context.repo.owner,
                 repo: github_1.context.repo.repo,
                 pull_number: github_1.context.payload.pull_request.number,
             });
-            return files.map(file => file.filename);
+            return entries.map(({ filename, status }) => ({ path: filename, status }));
         }
         catch (error) {
             core.setFailed(`Getting changed files failed with error: ${error}`);
@@ -264,6 +282,44 @@ function getChangedFilesImpl(token) {
         }
     });
 }
+
+
+/***/ }),
+
+/***/ 9091:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.stringifyForShell = void 0;
+function stringifyArrayItem(item) {
+    switch (typeof item) {
+        case 'number':
+            return item.toString();
+        case 'string':
+            return `'${item}'`;
+        default:
+            return JSON.stringify(item);
+    }
+}
+function stringifyForShell(value) {
+    switch (typeof value) {
+        case 'string':
+            return value;
+        case 'object':
+            if (Array.isArray(value)) {
+                return value.map(stringifyArrayItem).join(' ');
+            }
+            if (value === null) {
+                return '';
+            }
+            return value.toString();
+        default:
+            return JSON.stringify(value);
+    }
+}
+exports.stringifyForShell = stringifyForShell;
 
 
 /***/ }),
@@ -33661,7 +33717,7 @@ function run() {
         try {
             const pathPatterns = core.getInput(common_1.inputs.PATHS).split(';');
             const token = core.getInput(common_1.inputs.GH_TOKEN, { required: true });
-            const changedFiles = yield (0, common_1.getChangedFiles)(token);
+            const changedFiles = (yield (0, common_1.getChangedFiles)(token)).map(e => e.path);
             const filteredFiles = (0, common_1.filterPaths)(changedFiles, pathPatterns);
             core.setOutput(common_1.outputs.RESULT, filteredFiles.length > 0);
         }

--- a/pr-filter/dist/index.js
+++ b/pr-filter/dist/index.js
@@ -144,13 +144,15 @@ function filterPaths(paths, patterns) {
 }
 exports.filterPaths = filterPaths;
 function filterPathsImpl(paths, patterns) {
-    return paths.filter(path => {
-        return patterns.reduce((prevResult, pattern) => {
-            return pattern.startsWith(NEGATION)
-                ? prevResult && !match(path, pattern.substring(1))
-                : prevResult || match(path, pattern);
-        }, false);
-    });
+    return (patterns === null || patterns === void 0 ? void 0 : patterns.length) === 0
+        ? paths
+        : paths.filter(path => {
+            return patterns.reduce((prevResult, pattern) => {
+                return pattern.startsWith(NEGATION)
+                    ? prevResult && !match(path, pattern.substring(1))
+                    : prevResult || match(path, pattern);
+            }, false);
+        });
 }
 
 

--- a/pr-filter/dist/index.js
+++ b/pr-filter/dist/index.js
@@ -49,7 +49,6 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.outputs = exports.inputs = void 0;
 exports.inputs = {
     GH_TOKEN: 'gh-token',
-    OUTPUT: 'output',
     PATHS: 'paths',
 };
 exports.outputs = {

--- a/pr-filter/src/main.ts
+++ b/pr-filter/src/main.ts
@@ -7,7 +7,7 @@ async function run(): Promise<void> {
         const pathPatterns = core.getInput(inputs.PATHS).split(';');
         const token = core.getInput(inputs.GH_TOKEN, { required: true });
 
-        const changedFiles = await getChangedFiles(token);
+        const changedFiles = (await getChangedFiles(token)).map(e => e.path);
         const filteredFiles = filterPaths(changedFiles, pathPatterns);
 
         core.setOutput(outputs.RESULT, filteredFiles.length > 0);

--- a/verify-version-change/dist/index.js
+++ b/verify-version-change/dist/index.js
@@ -144,13 +144,15 @@ function filterPaths(paths, patterns) {
 }
 exports.filterPaths = filterPaths;
 function filterPathsImpl(paths, patterns) {
-    return paths.filter(path => {
-        return patterns.reduce((prevResult, pattern) => {
-            return pattern.startsWith(NEGATION)
-                ? prevResult && !match(path, pattern.substring(1))
-                : prevResult || match(path, pattern);
-        }, false);
-    });
+    return (patterns === null || patterns === void 0 ? void 0 : patterns.length) === 0
+        ? paths
+        : paths.filter(path => {
+            return patterns.reduce((prevResult, pattern) => {
+                return pattern.startsWith(NEGATION)
+                    ? prevResult && !match(path, pattern.substring(1))
+                    : prevResult || match(path, pattern);
+            }, false);
+        });
 }
 
 

--- a/verify-version-change/dist/index.js
+++ b/verify-version-change/dist/index.js
@@ -16,8 +16,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.execCommand = void 0;
+exports.setOutputs = exports.execCommand = void 0;
+const core_1 = __nccwpck_require__(5316);
 const exec_1 = __nccwpck_require__(110);
+const serialization_utils_1 = __nccwpck_require__(9091);
 function execCommand(command) {
     return __awaiter(this, void 0, void 0, function* () {
         const { stdout, stderr, exitCode } = yield (0, exec_1.getExecOutput)(command);
@@ -28,6 +30,12 @@ function execCommand(command) {
     });
 }
 exports.execCommand = execCommand;
+function setOutputs(values) {
+    for (const [key, value] of Object.entries(values)) {
+        (0, core_1.setOutput)(key, (0, serialization_utils_1.stringifyForShell)(value));
+    }
+}
+exports.setOutputs = setOutputs;
 
 
 /***/ }),
@@ -126,7 +134,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.filterPaths = void 0;
+exports.testPath = exports.normalizePatterns = exports.filterPaths = void 0;
 const core = __importStar(__nccwpck_require__(5316));
 const minimatch_1 = __nccwpck_require__(148);
 const NEGATION = '!';
@@ -144,16 +152,26 @@ function filterPaths(paths, patterns) {
 }
 exports.filterPaths = filterPaths;
 function filterPathsImpl(paths, patterns) {
-    return (patterns === null || patterns === void 0 ? void 0 : patterns.length) === 0
+    const normalizedPatterns = normalizePatterns(patterns);
+    return normalizedPatterns === undefined
         ? paths
-        : paths.filter(path => {
-            return patterns.reduce((prevResult, pattern) => {
-                return pattern.startsWith(NEGATION)
-                    ? prevResult && !match(path, pattern.substring(1))
-                    : prevResult || match(path, pattern);
-            }, false);
-        });
+        : paths.filter(path => testPath(path, normalizedPatterns));
 }
+function normalizePatterns(patterns) {
+    if (!patterns)
+        return undefined;
+    const notEmptyPatterns = patterns.filter(p => p != undefined && p.length > 0);
+    return (notEmptyPatterns.length > 0 ? notEmptyPatterns : undefined);
+}
+exports.normalizePatterns = normalizePatterns;
+function testPath(path, patterns) {
+    return patterns.reduce((prevResult, pattern) => {
+        return pattern.startsWith(NEGATION)
+            ? prevResult && !match(path, pattern.substring(1))
+            : prevResult || match(path, pattern);
+    }, false);
+}
+exports.testPath = testPath;
 
 
 /***/ }),
@@ -251,12 +269,12 @@ function getChangedFilesImpl(token) {
                 core.setFailed('Getting changed files only works on pull request events.');
                 return [];
             }
-            const files = yield octokit.paginate(octokit.rest.pulls.listFiles, {
+            const entries = yield octokit.paginate(octokit.rest.pulls.listFiles, {
                 owner: github_1.context.repo.owner,
                 repo: github_1.context.repo.repo,
                 pull_number: github_1.context.payload.pull_request.number,
             });
-            return files.map(file => file.filename);
+            return entries.map(({ filename, status }) => ({ path: filename, status }));
         }
         catch (error) {
             core.setFailed(`Getting changed files failed with error: ${error}`);
@@ -264,6 +282,44 @@ function getChangedFilesImpl(token) {
         }
     });
 }
+
+
+/***/ }),
+
+/***/ 9091:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.stringifyForShell = void 0;
+function stringifyArrayItem(item) {
+    switch (typeof item) {
+        case 'number':
+            return item.toString();
+        case 'string':
+            return `'${item}'`;
+        default:
+            return JSON.stringify(item);
+    }
+}
+function stringifyForShell(value) {
+    switch (typeof value) {
+        case 'string':
+            return value;
+        case 'object':
+            if (Array.isArray(value)) {
+                return value.map(stringifyArrayItem).join(' ');
+            }
+            if (value === null) {
+                return '';
+            }
+            return value.toString();
+        default:
+            return JSON.stringify(value);
+    }
+}
+exports.stringifyForShell = stringifyForShell;
 
 
 /***/ }),

--- a/verify-version-change/dist/index.js
+++ b/verify-version-change/dist/index.js
@@ -49,7 +49,6 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.outputs = exports.inputs = void 0;
 exports.inputs = {
     GH_TOKEN: 'gh-token',
-    OUTPUT: 'output',
     PATHS: 'paths',
 };
 exports.outputs = {


### PR DESCRIPTION
### Practical Value
Making the action feasible for usage in other use cases.

### Fixed the case with empty paths filter
The `paths` is not required, but if not specified, empty list of files returned.

#### Before
```yaml
    - uses: DevExpress/github-actions/get-changed-files@v1
      with:
        gh-token: XXX
        paths: '**/*'
        output: XXX
```

#### After
```yaml
    - uses: DevExpress/github-actions/get-changed-files@v1
      with:
        gh-token: XXX
        output: XXX
```

### Removed output
The files list is no longer saved to disk. Use the new json output instead, see usage examples.

### Added outpus

#### files
A list of all changed files in the PR. Usage example:

```yaml
    - run: |
        for file in ${{ steps.changed-files.outputs.files }}; do
          echo "$file"
        done
```


#### count
The number of all changed files in the PR. Usage example:
```yaml
    - if: steps.changed-files.outputs.count > 2
      run: |
        echo "${{ steps.changed-files.outputs.count }}"
```

#### json

All data in JSON format, e.g. to use with [`jq`](https://play.jqlang.org/)
Data Schema:
```typescript
type JsonSchema = {
  files: {
    path: string;
    status: string;
  } [];
  count: number;
};
```
Data sample:
```json
{
  "files": [
    {
      "path": "path/to/file-0.txt",
      "status": "modified"
    },
    {
      "path": "file-1.ts",
      "status": "removed"
    },
    {
      "path": "file-2.js",
      "status": "modified"
    },
    {
      "path": "file-3.yaml",
      "status": "added"
    }
  ],
  "count": 4
}
```

Usage examples:
```yaml
    # conditional step
    - if: fromJSON(steps.changed-files.outputs.json).count > 2
      run: |
        echo "${{ fromJSON(steps.changed-files.outputs.json).count }}"

    # output to disk
    - run: |
        jq -r <<< '${{ steps.changed-files.outputs.json }}' > changed-files-2.json

    # change data structure
    # [
    #   { "filename": "path/to/file1" },
    #   ...
    # ]
    - run: |
        jq -r '[.files[] | {filename: .path}]' <<< '${{ steps.changed-files.outputs.json }}' 

    # filter files by status  and change data structure:
    # file1
    # file2
    # ...
    -  run: |
        jq -r '.files[] | select(.status != "removed") | .path' <<< '${{ steps.changed-files.outputs.json }}'

```
