### PR TITLE
Add validate-sbom action

### DIFF
--- a/common/src/path-utils.test.ts
+++ b/common/src/path-utils.test.ts
@@ -1,4 +1,4 @@
-import { filterPaths } from "./path-utils";
+import { filterPaths, splitPaths } from "./path-utils";
 
 describe('path utils', () => {
 
@@ -87,6 +87,33 @@ describe('path utils', () => {
             },
         ])('specific cases [%#]', ({ paths, patterns, expected }) => {
             expect(filterPaths(paths, patterns)).toEqual(expected);
+        });
+    });
+
+    describe('splitPaths', () => {
+        test.each([
+            {
+                paths: '',
+                expected: []
+            },
+            {
+                paths: 'a.cdx.json',
+                expected: ['a.cdx.json']
+            },
+            {
+                paths: 'a.cdx.json,b.cdx.json',
+                expected: ['a.cdx.json', 'b.cdx.json']
+            },
+            {
+                paths: 'a.cdx.json;b.cdx.json',
+                expected: ['a.cdx.json', 'b.cdx.json']
+            },
+            {
+                paths: 'a.cdx.json\r\nb.cdx.json\n c.cdx.json ',
+                expected: ['a.cdx.json', 'b.cdx.json', 'c.cdx.json']
+            },
+        ])('basic cases [%#]', ({ paths, expected }) => {
+            expect(splitPaths(paths)).toEqual(expected);
         });
     });
 });

--- a/common/src/path-utils.ts
+++ b/common/src/path-utils.ts
@@ -32,3 +32,10 @@ function filterPathsImpl(
         }, false);
     });
 }
+
+export function splitPaths(paths: string): string[] {
+    return paths
+        .split(/[\r\n,;]+/)
+        .map(path => path.trim())
+        .filter(path => path.length > 0);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,30 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
 
+  validate-sbom:
+    devDependencies:
+      '@actions/core':
+        specifier: 'catalog:'
+        version: 2.0.3
+      '@actions/exec':
+        specifier: 'catalog:'
+        version: 2.0.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.1
+      '@vercel/ncc':
+        specifier: 'catalog:'
+        version: 0.38.4
+      common:
+        specifier: workspace:*
+        version: link:../common
+      rimraf:
+        specifier: 'catalog:'
+        version: 6.1.3
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+
   verify-version-change:
     devDependencies:
       '@actions/core':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - get-changed-files
   - pr-filter
   - send-teams-notification
+  - validate-sbom
   - verify-version-change
 
 catalog:

--- a/pr-filter/dist/index.js
+++ b/pr-filter/dist/index.js
@@ -124,6 +124,7 @@ var __importStar = (this && this.__importStar) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.filterPaths = filterPaths;
+exports.splitPaths = splitPaths;
 const core = __importStar(__nccwpck_require__(1751));
 const minimatch_1 = __nccwpck_require__(4804);
 const NEGATION = '!';
@@ -147,6 +148,12 @@ function filterPathsImpl(paths, patterns) {
                 : prevResult || match(path, pattern);
         }, false);
     });
+}
+function splitPaths(paths) {
+    return paths
+        .split(/[\r\n,;]+/)
+        .map(path => path.trim())
+        .filter(path => path.length > 0);
 }
 
 

--- a/validate-sbom/action.yml
+++ b/validate-sbom/action.yml
@@ -12,7 +12,10 @@ inputs:
     default: json
   input-file:
     description: Path to the SBOM file to validate.
-    required: true
+    required: false
+  input-files:
+    description: Newline-separated paths to SBOM files to validate.
+    required: false
 
 runs:
   using: composite
@@ -45,5 +48,27 @@ runs:
 
     - name: Validate SBOM
       shell: bash
+      env:
+        INPUT_FILE: ${{ inputs.input-file }}
+        INPUT_FILES: ${{ inputs.input-files }}
       run: |
-        cyclonedx validate --fail-on-errors --input-format "${{ inputs.input-format }}" --input-file "${{ inputs.input-file }}"
+        input_files=()
+
+        if [[ -n "$INPUT_FILE" ]]; then
+          input_files+=("$INPUT_FILE")
+        fi
+
+        while IFS= read -r input_file; do
+          if [[ -n "$input_file" ]]; then
+            input_files+=("$input_file")
+          fi
+        done <<< "$INPUT_FILES"
+
+        if [[ "${#input_files[@]}" -eq 0 ]]; then
+          echo "Set input-file or input-files."
+          exit 1
+        fi
+
+        for input_file in "${input_files[@]}"; do
+          cyclonedx validate --fail-on-errors --input-format "${{ inputs.input-format }}" --input-file "$input_file"
+        done

--- a/validate-sbom/action.yml
+++ b/validate-sbom/action.yml
@@ -1,16 +1,16 @@
-name: Validate SBOM
-description: Install CycloneDX CLI and validate a CycloneDX SBOM file.
+name: validate-sbom
+description: Install CycloneDX CLI and validate SBOM file(s)
 
 inputs:
   input-format:
-    description: SBOM input format.
+    description: SBOM file format
     required: false
     default: json
   input-file:
-    description: Path to the SBOM file to validate.
+    description: Path to SBOM file to validate
     required: false
   input-files:
-    description: Newline, comma, or semicolon separated paths to SBOM files to validate.
+    description: Newline, comma, or semicolon separated paths to SBOM files to validate
     required: false
 
 runs:

--- a/validate-sbom/action.yml
+++ b/validate-sbom/action.yml
@@ -2,10 +2,6 @@ name: Validate SBOM
 description: Install CycloneDX CLI and validate a CycloneDX SBOM file.
 
 inputs:
-  cyclonedx-version:
-    description: CycloneDX CLI version to install.
-    required: false
-    default: 0.32.0
   input-format:
     description: SBOM input format.
     required: false
@@ -14,61 +10,9 @@ inputs:
     description: Path to the SBOM file to validate.
     required: false
   input-files:
-    description: Newline-separated paths to SBOM files to validate.
+    description: Newline, comma, or semicolon separated paths to SBOM files to validate.
     required: false
 
 runs:
-  using: composite
-  steps:
-    - name: Install CycloneDX CLI
-      shell: bash
-      run: |
-        tool_dir="$RUNNER_TEMP/cyclonedx-cli"
-        mkdir -p "$tool_dir"
-
-        if [[ "$RUNNER_OS" == "Linux" ]]; then
-          file=cyclonedx-linux-x64
-          bin=cyclonedx
-          sha256=454879e6a4a405c8a13bff49b8982adcb0596f3019b26b0811c66e4d7f0783e1
-        elif [[ "$RUNNER_OS" == "Windows" ]]; then
-          file=cyclonedx-win-x64.exe
-          bin=cyclonedx.exe
-          sha256=b1c00dbb40e628ec8c1252771871341ac4d4aaf032f832d83bd22cb2b1d258ae
-        else
-          file=cyclonedx-osx-arm64
-          bin=cyclonedx
-          sha256=83be8a9599f1dce1252208bd4d0bb15308eca0546814fb72b48b7246d35e832e
-        fi
-
-        curl -fsSL "https://github.com/CycloneDX/cyclonedx-cli/releases/download/v${{ inputs.cyclonedx-version }}/${file}" -o "$tool_dir/$bin"
-        cd "$tool_dir"
-        echo "$sha256  $bin" | sha256sum -c -
-        chmod +x "$tool_dir/$bin" || true
-        echo "$tool_dir" >> "$GITHUB_PATH"
-
-    - name: Validate SBOM
-      shell: bash
-      env:
-        INPUT_FILE: ${{ inputs.input-file }}
-        INPUT_FILES: ${{ inputs.input-files }}
-      run: |
-        input_files=()
-
-        if [[ -n "$INPUT_FILE" ]]; then
-          input_files+=("$INPUT_FILE")
-        fi
-
-        while IFS= read -r input_file; do
-          if [[ -n "$input_file" ]]; then
-            input_files+=("$input_file")
-          fi
-        done <<< "$INPUT_FILES"
-
-        if [[ "${#input_files[@]}" -eq 0 ]]; then
-          echo "Set input-file or input-files."
-          exit 1
-        fi
-
-        for input_file in "${input_files[@]}"; do
-          cyclonedx validate --fail-on-errors --input-format "${{ inputs.input-format }}" --input-file "$input_file"
-        done
+  using: node24
+  main: dist/index.js

--- a/validate-sbom/action.yml
+++ b/validate-sbom/action.yml
@@ -1,0 +1,49 @@
+name: Validate SBOM
+description: Install CycloneDX CLI and validate a CycloneDX SBOM file.
+
+inputs:
+  cyclonedx-version:
+    description: CycloneDX CLI version to install.
+    required: false
+    default: 0.32.0
+  input-format:
+    description: SBOM input format.
+    required: false
+    default: json
+  input-file:
+    description: Path to the SBOM file to validate.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install CycloneDX CLI
+      shell: bash
+      run: |
+        tool_dir="$RUNNER_TEMP/cyclonedx-cli"
+        mkdir -p "$tool_dir"
+
+        if [[ "$RUNNER_OS" == "Linux" ]]; then
+          file=cyclonedx-linux-x64
+          bin=cyclonedx
+          sha256=454879e6a4a405c8a13bff49b8982adcb0596f3019b26b0811c66e4d7f0783e1
+        elif [[ "$RUNNER_OS" == "Windows" ]]; then
+          file=cyclonedx-win-x64.exe
+          bin=cyclonedx.exe
+          sha256=b1c00dbb40e628ec8c1252771871341ac4d4aaf032f832d83bd22cb2b1d258ae
+        else
+          file=cyclonedx-osx-arm64
+          bin=cyclonedx
+          sha256=83be8a9599f1dce1252208bd4d0bb15308eca0546814fb72b48b7246d35e832e
+        fi
+
+        curl -fsSL "https://github.com/CycloneDX/cyclonedx-cli/releases/download/v${{ inputs.cyclonedx-version }}/${file}" -o "$tool_dir/$bin"
+        cd "$tool_dir"
+        echo "$sha256  $bin" | sha256sum -c -
+        chmod +x "$tool_dir/$bin" || true
+        echo "$tool_dir" >> "$GITHUB_PATH"
+
+    - name: Validate SBOM
+      shell: bash
+      run: |
+        cyclonedx validate --fail-on-errors --input-format "${{ inputs.input-format }}" --input-file "${{ inputs.input-file }}"

--- a/validate-sbom/dist/index.js
+++ b/validate-sbom/dist/index.js
@@ -260,81 +260,6 @@ async function getChangedFilesImpl(token) {
 
 /***/ }),
 
-/***/ 9144:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
-
-"use strict";
-
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-const fs = __importStar(__nccwpck_require__(9896));
-const core = __importStar(__nccwpck_require__(1751));
-const common_1 = __nccwpck_require__(1851);
-function run() {
-    return __awaiter(this, void 0, void 0, function* () {
-        try {
-            const pathPatterns = core.getInput(common_1.inputs.PATHS).split(';');
-            const token = core.getInput(common_1.inputs.GH_TOKEN, { required: true });
-            const output = core.getInput(common_1.inputs.OUTPUT, { required: true });
-            console.log('patterns: ' + JSON.stringify(pathPatterns, undefined, 2));
-            const changedFiles = yield (0, common_1.getChangedFiles)(token);
-            const filteredFiles = (0, common_1.filterPaths)(changedFiles, pathPatterns);
-            (0, common_1.ensureDir)(output);
-            fs.writeFileSync(output, JSON.stringify(filteredFiles.map(filename => ({ filename })), undefined, 2));
-        }
-        catch (error) {
-            if (error instanceof Error) {
-                core.setFailed(error.message);
-            }
-        }
-    });
-}
-run();
-
-
-/***/ }),
-
 /***/ 3791:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
@@ -31890,6 +31815,187 @@ function onParserError (err) {
 module.exports = {
   WebSocket
 }
+
+
+/***/ }),
+
+/***/ 9144:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+const core = __importStar(__nccwpck_require__(1751));
+const exec_1 = __nccwpck_require__(6932);
+const crypto_1 = __nccwpck_require__(6982);
+const fs_1 = __nccwpck_require__(9896);
+const https_1 = __nccwpck_require__(5692);
+const os_1 = __nccwpck_require__(857);
+const path_1 = __nccwpck_require__(6928);
+const common_1 = __nccwpck_require__(1851);
+const CYCLONEDX_CLI_VERSION = '0.32.0';
+const inputs = {
+    INPUT_FILE: 'input-file',
+    INPUT_FILES: 'input-files',
+    INPUT_FORMAT: 'input-format',
+};
+const CYCLONEDX_CLI_ASSETS = {
+    Linux: {
+        file: 'cyclonedx-linux-x64',
+        bin: 'cyclonedx',
+        sha256: '454879e6a4a405c8a13bff49b8982adcb0596f3019b26b0811c66e4d7f0783e1',
+    },
+    Windows: {
+        file: 'cyclonedx-win-x64.exe',
+        bin: 'cyclonedx.exe',
+        sha256: 'b1c00dbb40e628ec8c1252771871341ac4d4aaf032f832d83bd22cb2b1d258ae',
+    },
+    macOS: {
+        file: 'cyclonedx-osx-arm64',
+        bin: 'cyclonedx',
+        sha256: '83be8a9599f1dce1252208bd4d0bb15308eca0546814fb72b48b7246d35e832e',
+    },
+};
+function run() {
+    return __awaiter(this, void 0, void 0, function* () {
+        try {
+            const inputFormat = core.getInput(inputs.INPUT_FORMAT) || 'json';
+            const inputFile = core.getInput(inputs.INPUT_FILE, { required: false });
+            const inputFiles = core.getInput(inputs.INPUT_FILES, { required: false });
+            const files = [
+                ...(0, common_1.splitPaths)(inputFile),
+                ...(0, common_1.splitPaths)(inputFiles),
+            ];
+            if (files.length === 0) {
+                throw new Error('Set input-file or input-files.');
+            }
+            const cyclonedxPath = yield installCycloneDxCli(CYCLONEDX_CLI_VERSION);
+            for (const file of files) {
+                yield validateSbom(cyclonedxPath, inputFormat, file);
+            }
+        }
+        catch (error) {
+            if (error instanceof Error) {
+                core.setFailed(error.message);
+            }
+            else {
+                core.setFailed(String(error));
+            }
+        }
+    });
+}
+function installCycloneDxCli(version) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const runnerOs = process.env.RUNNER_OS || 'Linux';
+        const asset = CYCLONEDX_CLI_ASSETS[runnerOs] || CYCLONEDX_CLI_ASSETS.macOS;
+        const toolDir = (0, path_1.join)(process.env.RUNNER_TEMP || (0, os_1.tmpdir)(), 'cyclonedx-cli');
+        const toolPath = (0, path_1.join)(toolDir, asset.bin);
+        const downloadUrl = `https://github.com/CycloneDX/cyclonedx-cli/releases/download/v${version}/${asset.file}`;
+        (0, fs_1.mkdirSync)(toolDir, { recursive: true });
+        yield downloadFile(downloadUrl, toolPath);
+        verifySha256(toolPath, asset.sha256);
+        try {
+            (0, fs_1.chmodSync)(toolPath, 0o755);
+        }
+        catch (_a) {
+            core.debug(`Unable to chmod ${toolPath}.`);
+        }
+        return toolPath;
+    });
+}
+function validateSbom(cyclonedxPath, inputFormat, inputFile) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const { exitCode, stdout, stderr } = yield (0, exec_1.getExecOutput)(cyclonedxPath, [
+            'validate',
+            '--fail-on-errors',
+            '--input-format',
+            inputFormat,
+            '--input-file',
+            inputFile,
+        ], {
+            ignoreReturnCode: true,
+        });
+        if (exitCode !== 0) {
+            throw new Error(`CycloneDX validation failed for "${inputFile}": ${stderr || stdout}`);
+        }
+    });
+}
+function downloadFile(url_1, destination_1) {
+    return __awaiter(this, arguments, void 0, function* (url, destination, redirectCount = 0) {
+        if (redirectCount > 5) {
+            throw new Error(`Too many redirects while downloading ${url}.`);
+        }
+        return new Promise((resolve, reject) => {
+            (0, https_1.get)(url, response => {
+                const statusCode = response.statusCode || 0;
+                const location = response.headers.location;
+                if ([301, 302, 303, 307, 308].includes(statusCode) && location) {
+                    response.resume();
+                    downloadFile(new URL(location, url).toString(), destination, redirectCount + 1).then(resolve, reject);
+                    return;
+                }
+                if (statusCode !== 200) {
+                    response.resume();
+                    reject(new Error(`Download failed with HTTP ${statusCode}: ${url}`));
+                    return;
+                }
+                const file = (0, fs_1.createWriteStream)(destination);
+                response.pipe(file);
+                file.on('finish', () => file.close(error => error ? reject(error) : resolve()));
+                file.on('error', reject);
+            }).on('error', reject);
+        });
+    });
+}
+function verifySha256(path, expectedSha256) {
+    const actualSha256 = (0, crypto_1.createHash)('sha256').update((0, fs_1.readFileSync)(path)).digest('hex');
+    if (actualSha256 !== expectedSha256) {
+        throw new Error(`Invalid CycloneDX CLI checksum. Expected ${expectedSha256}, got ${actualSha256}.`);
+    }
+}
+run();
 
 
 /***/ }),

--- a/validate-sbom/dist/index.js
+++ b/validate-sbom/dist/index.js
@@ -31929,7 +31929,10 @@ function run() {
 function installCycloneDxCli(version) {
     return __awaiter(this, void 0, void 0, function* () {
         const runnerOs = process.env.RUNNER_OS || 'Linux';
-        const asset = CYCLONEDX_CLI_ASSETS[runnerOs] || CYCLONEDX_CLI_ASSETS.macOS;
+        const asset = CYCLONEDX_CLI_ASSETS[runnerOs];
+        if (!asset) {
+            throw new Error(`Unsupported runner OS: ${runnerOs}.`);
+        }
         const toolDir = (0, path_1.join)(process.env.RUNNER_TEMP || (0, os_1.tmpdir)(), 'cyclonedx-cli');
         const toolPath = (0, path_1.join)(toolDir, asset.bin);
         const downloadUrl = `https://github.com/CycloneDX/cyclonedx-cli/releases/download/v${version}/${asset.file}`;

--- a/validate-sbom/package.json
+++ b/validate-sbom/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "validate-sbom",
+  "description": "GitHub action that validates CycloneDX SBOM files",
+  "version": "1.0.0",
+  "author": "Developer Express Inc.",
+  "license": "MIT",
+  "engines": {
+    "node": ">=24.15.0"
+  },
+  "main": "lib/main.js",
+  "scripts": {
+    "clean": "rimraf dist lib",
+    "build": "tsc",
+    "dist": "ncc build"
+  },
+  "devDependencies": {
+    "@actions/core": "catalog:",
+    "@actions/exec": "catalog:",
+    "@types/node": "catalog:",
+    "@vercel/ncc": "catalog:",
+    "common": "workspace:*",
+    "rimraf": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/validate-sbom/src/main.ts
+++ b/validate-sbom/src/main.ts
@@ -1,0 +1,147 @@
+import * as core from '@actions/core';
+import { getExecOutput } from '@actions/exec';
+
+import { createHash } from 'crypto';
+import { createWriteStream, chmodSync, mkdirSync, readFileSync } from 'fs';
+import { get } from 'https';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { splitPaths } from 'common';
+
+type CycloneDxCliAsset = {
+    file: string;
+    bin: string;
+    sha256: string;
+};
+
+const CYCLONEDX_CLI_VERSION = '0.32.0';
+const inputs = {
+    INPUT_FILE: 'input-file',
+    INPUT_FILES: 'input-files',
+    INPUT_FORMAT: 'input-format',
+} as const;
+
+const CYCLONEDX_CLI_ASSETS: Record<string, CycloneDxCliAsset> = {
+    Linux: {
+        file: 'cyclonedx-linux-x64',
+        bin: 'cyclonedx',
+        sha256: '454879e6a4a405c8a13bff49b8982adcb0596f3019b26b0811c66e4d7f0783e1',
+    },
+    Windows: {
+        file: 'cyclonedx-win-x64.exe',
+        bin: 'cyclonedx.exe',
+        sha256: 'b1c00dbb40e628ec8c1252771871341ac4d4aaf032f832d83bd22cb2b1d258ae',
+    },
+    macOS: {
+        file: 'cyclonedx-osx-arm64',
+        bin: 'cyclonedx',
+        sha256: '83be8a9599f1dce1252208bd4d0bb15308eca0546814fb72b48b7246d35e832e',
+    },
+};
+
+async function run(): Promise<void> {
+    try {
+        const inputFormat = core.getInput(inputs.INPUT_FORMAT) || 'json';
+        const inputFile = core.getInput(inputs.INPUT_FILE, { required: false });
+        const inputFiles = core.getInput(inputs.INPUT_FILES, { required: false });
+        const files = [
+            ...splitPaths(inputFile),
+            ...splitPaths(inputFiles),
+        ];
+
+        if (files.length === 0) {
+            throw new Error('Set input-file or input-files.');
+        }
+
+        const cyclonedxPath = await installCycloneDxCli(CYCLONEDX_CLI_VERSION);
+
+        for (const file of files) {
+            await validateSbom(cyclonedxPath, inputFormat, file);
+        }
+    } catch (error) {
+        if (error instanceof Error) {
+            core.setFailed(error.message);
+        } else {
+            core.setFailed(String(error));
+        }
+    }
+}
+
+async function installCycloneDxCli(version: string): Promise<string> {
+    const runnerOs = process.env.RUNNER_OS || 'Linux';
+    const asset = CYCLONEDX_CLI_ASSETS[runnerOs] || CYCLONEDX_CLI_ASSETS.macOS;
+    const toolDir = join(process.env.RUNNER_TEMP || tmpdir(), 'cyclonedx-cli');
+    const toolPath = join(toolDir, asset.bin);
+    const downloadUrl = `https://github.com/CycloneDX/cyclonedx-cli/releases/download/v${version}/${asset.file}`;
+
+    mkdirSync(toolDir, { recursive: true });
+    await downloadFile(downloadUrl, toolPath);
+    verifySha256(toolPath, asset.sha256);
+
+    try {
+        chmodSync(toolPath, 0o755);
+    } catch {
+        core.debug(`Unable to chmod ${toolPath}.`);
+    }
+
+    return toolPath;
+}
+
+async function validateSbom(cyclonedxPath: string, inputFormat: string, inputFile: string): Promise<void> {
+    const { exitCode, stdout, stderr } = await getExecOutput(cyclonedxPath, [
+        'validate',
+        '--fail-on-errors',
+        '--input-format',
+        inputFormat,
+        '--input-file',
+        inputFile,
+    ], {
+        ignoreReturnCode: true,
+    });
+
+    if (exitCode !== 0) {
+        throw new Error(`CycloneDX validation failed for "${inputFile}": ${stderr || stdout}`);
+    }
+}
+
+async function downloadFile(url: string, destination: string, redirectCount = 0): Promise<void> {
+    if (redirectCount > 5) {
+        throw new Error(`Too many redirects while downloading ${url}.`);
+    }
+
+    return new Promise((resolve, reject) => {
+        get(url, response => {
+            const statusCode = response.statusCode || 0;
+            const location = response.headers.location;
+
+            if ([301, 302, 303, 307, 308].includes(statusCode) && location) {
+                response.resume();
+                downloadFile(new URL(location, url).toString(), destination, redirectCount + 1).then(resolve, reject);
+                return;
+            }
+
+            if (statusCode !== 200) {
+                response.resume();
+                reject(new Error(`Download failed with HTTP ${statusCode}: ${url}`));
+                return;
+            }
+
+            const file = createWriteStream(destination);
+
+            response.pipe(file);
+            file.on('finish', () => file.close(error => error ? reject(error) : resolve()));
+            file.on('error', reject);
+        }).on('error', reject);
+    });
+}
+
+function verifySha256(path: string, expectedSha256: string): void {
+    const actualSha256 = createHash('sha256').update(readFileSync(path)).digest('hex');
+
+    if (actualSha256 !== expectedSha256) {
+        throw new Error(`Invalid CycloneDX CLI checksum. Expected ${expectedSha256}, got ${actualSha256}.`);
+    }
+}
+
+run();

--- a/validate-sbom/src/main.ts
+++ b/validate-sbom/src/main.ts
@@ -70,7 +70,12 @@ async function run(): Promise<void> {
 
 async function installCycloneDxCli(version: string): Promise<string> {
     const runnerOs = process.env.RUNNER_OS || 'Linux';
-    const asset = CYCLONEDX_CLI_ASSETS[runnerOs] || CYCLONEDX_CLI_ASSETS.macOS;
+    const asset = CYCLONEDX_CLI_ASSETS[runnerOs];
+
+    if (!asset) {
+        throw new Error(`Unsupported runner OS: ${runnerOs}.`);
+    }
+
     const toolDir = join(process.env.RUNNER_TEMP || tmpdir(), 'cyclonedx-cli');
     const toolPath = join(toolDir, asset.bin);
     const downloadUrl = `https://github.com/CycloneDX/cyclonedx-cli/releases/download/v${version}/${asset.file}`;

--- a/validate-sbom/tsconfig.json
+++ b/validate-sbom/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "CommonJS",
+    "outDir": "./lib",
+    "rootDir": "./src",
+    "baseUrl": "./",
+    "strict": true,
+    "noImplicitAny": true,
+    "esModuleInterop": true
+  },
+  "exclude": ["node_modules"]
+}

--- a/validate-sbom/tsconfig.json
+++ b/validate-sbom/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES6",
+    "types": ["node"],
     "module": "CommonJS",
     "outDir": "./lib",
     "rootDir": "./src",

--- a/verify-version-change/dist/index.js
+++ b/verify-version-change/dist/index.js
@@ -124,6 +124,7 @@ var __importStar = (this && this.__importStar) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.filterPaths = filterPaths;
+exports.splitPaths = splitPaths;
 const core = __importStar(__nccwpck_require__(1751));
 const minimatch_1 = __nccwpck_require__(4804);
 const NEGATION = '!';
@@ -147,6 +148,12 @@ function filterPathsImpl(paths, patterns) {
                 : prevResult || match(path, pattern);
         }, false);
     });
+}
+function splitPaths(paths) {
+    return paths
+        .split(/[\r\n,;]+/)
+        .map(path => path.trim())
+        .filter(path => path.length > 0);
 }
 
 


### PR DESCRIPTION
Adds a shared GitHub Action for validating CycloneDX SBOM files in CI.

The action downloads a pinned CycloneDX CLI binary, verifies its SHA-256 checksum, and runs `cyclonedx validate --fail-on-errors` against one or more provided SBOM files. It supports validating a single file via `input-file` or multiple files via `input-files`, where paths may be separated by newlines, commas, or semicolons.

The action runs on Node 24, uses CycloneDX CLI `0.32.0`, and selects the correct binary based on `RUNNER_OS`. If `RUNNER_OS` is missing, it defaults to Linux. Unsupported runner OS values fail explicitly with a clear error.

### Usage

```yaml
- name: Validate SBOM
  uses: DevExpress/github-actions/validate-sbom@main
  with:
    input-format: json
    input-file: sbom.cdx.json
```

Multiple files:

```
- name: Validate SBOM files
  uses: DevExpress/github-actions/validate-sbom@main
  with:
    input-format: json
    input-files: |
      package-a/sbom.cdx.json
      package-b/sbom.cdx.json
      package-c/sbom.cdx.json
```

### Inputs
- input-format
SBOM file format passed to CycloneDX CLI. Defaults to json.

- input-file
Path to a single SBOM file to validate.

- input-files
Newline, comma, or semicolon separated paths to SBOM files.

At least one of input-file or input-files must be provided.

### Failure Conditions
The action fails when no SBOM file is provided, the runner OS is unsupported, the CycloneDX CLI download or checksum verification fails, or CycloneDX reports validation errors for any SBOM file.